### PR TITLE
Small fix for use_fofR and numpy version

### DIFF
--- a/environment-pip.yml
+++ b/environment-pip.yml
@@ -7,7 +7,7 @@ dependencies:
   - pip>=19.0
   - pip:
     - cython
-    - numpy>=1.17
+    - numpy>=1.17,<=1.23
     - scipy>=1.3
     - jupyter>=1.0
     - matplotlib>=3.1


### PR DESCRIPTION
Creating this pull request to fix an error on use_fofR and to add requirement for numpy<=1.23 in preparation of FORGE.

To explain further, it seems that if `use_fofR=='Winther'` that does not equal True, so the code never adds the `lnfR0` to the nuisance parameters list. Fortunately, 'Winther' is also not equal to False, so reversing the logic works.

I also added the requirement for numpy to not be version 1.24 as FORGE does not like that.

Just noticed my IDE also automatically removed some spaces, so there appear to be more changes, sorry about that.

Let me know if you have any questions.